### PR TITLE
Fix: removed public/ from MY_IP

### DIFF
--- a/rtpengine.conf
+++ b/rtpengine.conf
@@ -1,5 +1,5 @@
 [rtpengine]
-interface=public/MY_IP
+interface=MY_IP
 foreground=true
 log-stderr=true
 listen-ng=MY_IP:22222


### PR DESCRIPTION
Substituting of `MY_IP="$LOCAL_IP"!"$PUBLIC_IP"` will never happen because of `interface=public/MY_IP` in the rtpengine.conf. Instead, the result is `public/$LOCAL_IP`, which is probably wrong. Removing `public/` solves the problem.